### PR TITLE
ZFS send wrapper --restrict-raw/glob, --raw support

### DIFF
--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -95,12 +95,19 @@ class ZFSTarget (BaseTarget):
         log.debug("%s setup: get_error=%s, zfs_source=%s", self, get_error, zfs_source)
 
         if get_error:
-            if create:
-                # assume error is caused by missing fs
+            if not create:
+                raise get_error
+
+            elif self.rsync_source:
+                # create for mount/rsync
                 self.create(verify_source)
 
+            elif self.zfs_source:
+                # will be created by zfs recv
+                pass
+
             else:
-                raise get_error
+                raise Error("{zfs}: local dataset is missing".format(zfs=self.zfs))
 
         elif verify_source and zfs_source != verify_source:
             if force_source:
@@ -127,7 +134,7 @@ class ZFSTarget (BaseTarget):
 
         return mountpoint
 
-    def snapshot (self, now):
+    def snapshot (self, now, create=False):
         """
             Create new ZFS snapshot for given timestamp.
 
@@ -156,8 +163,11 @@ class ZFSTarget (BaseTarget):
             try:
                 local_snapshot = self.zfs.last_snapshot().name
             except qmsk.backup.zfs.ZFSError as error:
-                log.warning("%s: requesting full send for local ZFS that is assumed to be missing: %s", self, error)
-                incremental_bookmark = None
+                if create:
+                    log.warning("%s: requesting full send for local ZFS that is assumed to be missing: %s", self, error)
+                    incremental_bookmark = None
+                else:
+                    raise Error("{zfs}: local ZFS is missing, use --setup-create".format(zfs=self.zfs))
             else:
                 incremental_bookmark = self.zfs_bookmark + ':' + local_snapshot
 
@@ -172,7 +182,14 @@ class ZFSTarget (BaseTarget):
                 purge_bookmark  = incremental_bookmark, # destroy bookmark for incremental snapshot
             ) as stream:
                 # create new snapshot with desired name
-                snapshot = self.zfs.receive(snapshot_name, force=True, stdin=stream)
+                # implicitly creates dataset if missing
+                snapshot = self.zfs.receive(snapshot_name,
+                    force       = True,
+                    properties  = {
+                        'qmsk-backup:source': str(self.zfs_source),
+                    },
+                    stdin       = stream,
+                )
 
             # set properties
             snapshot.set('qmsk-backup:snapshot', snapshot_name)
@@ -198,7 +215,7 @@ class ZFSTarget (BaseTarget):
 
         snapshot.hold(interval_hold)
 
-    def backup (self):
+    def backup (self, create=None):
         """
             Run backup, managing snapshots.
         """
@@ -208,7 +225,7 @@ class ZFSTarget (BaseTarget):
 
         log.info("%s: backup %s", self, now)
 
-        snapshot = self.snapshot(now)
+        snapshot = self.snapshot(now, create=create)
 
         # manage intervals
         for interval in self.intervals:
@@ -373,7 +390,9 @@ def main (args):
             )
 
             if not args.skip_backup:
-                target.backup()
+                target.backup(
+                        create          = args.setup_create,
+                )
 
             # purge intervals
             if args.purge:

--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -34,6 +34,7 @@ class ZFSTarget (BaseTarget):
     def config (cls, name,
             noop        = None,
             zfs_source      = None,
+            zfs_raw         = None,
             zfs_bookmark    = None,
             invoker_options = {},
             ssh_options     = {},
@@ -51,15 +52,17 @@ class ZFSTarget (BaseTarget):
                     invoker = qmsk.invoke.Invoker(**invoker_options),
                 ),
                 zfs_source      = zfs_source,
+                zfs_raw         = zfs_raw,
                 zfs_bookmark    = zfs_bookmark,
                 **opts
         )
 
-    def __init__ (self, zfs, zfs_source=None, zfs_bookmark=None, **opts):
+    def __init__ (self, zfs, zfs_source=None, zfs_raw=None, zfs_bookmark=None, **opts):
         super(ZFSTarget, self).__init__(**opts)
 
         self.zfs = zfs
         self.zfs_source = zfs_source
+        self.zfs_raw = zfs_raw
         self.zfs_bookmark = zfs_bookmark
 
     def __str__ (self):
@@ -162,6 +165,7 @@ class ZFSTarget (BaseTarget):
             send_bookmark = self.zfs_bookmark + ':' + snapshot_name
 
             with self.zfs_source.stream_send(
+                raw             = self.zfs_raw,
                 incremental     = '#' + incremental_bookmark if incremental_bookmark else None,
                 snapshot        = None, # create temporary snapshot
                 bookmark        = send_bookmark, # create bookmark for sent snapshot
@@ -311,6 +315,8 @@ def main (args):
     # ZFS send/recv
     parser.add_argument('--zfs-source', metavar='HOST:ZFS',
             help="ZFS send/recv from SSH remote or local pool")
+    parser.add_argument('--zfs-raw', action='store_true',
+            help="ZFS send --raw of encrypted dataset")
     parser.add_argument('--zfs-bookmark', metavar='BOOKMARK-PREFIX', default=ZFS_BOOKMARK,
             help="Sender bookmark prefix")
     parser.add_argument('--ssh-config', metavar='PATH')
@@ -336,6 +342,7 @@ def main (args):
                     rsync_source    = args.rsync_source,
                     rsync_options   = args.rsync_options,
                     zfs_source      = args.zfs_source,
+                    zfs_raw         = args.zfs_raw,
                     zfs_bookmark    = args.zfs_bookmark,
                     invoker_options = dict(
                         sudo            = args.sudo,

--- a/bin/qmsk.zfs-ssh-command
+++ b/bin/qmsk.zfs-ssh-command
@@ -24,6 +24,9 @@ import shlex
 
 log = logging.getLogger('qmsk.backup-ssh-command')
 
+class Error (Exception):
+    pass
+
 @contextlib.contextmanager
 def wrap_context(value):
     """
@@ -37,9 +40,10 @@ class Wrapper:
         Command wrapper
     """
 
-    def __init__(self, noop=None, sudo=None):
+    def __init__(self, noop=None, sudo=None, restrict_raw=None):
         self.noop = noop
         self.sudo = sudo
+        self.restrict_raw = restrict_raw
 
     def zfs_send(self, args):
         target = args.zfs
@@ -49,6 +53,9 @@ class Wrapper:
         else:
             zfs_name = target
             snapshot_name = None
+
+        if self.restrict_raw and not args.raw:
+            raise Error("Only --raw sends are allowed")
 
         zfs = qmsk.backup.zfs.open(zfs_name,
             noop    = self.noop,
@@ -151,6 +158,9 @@ def main (args):
     parser.add_argument('--sudo',             action='store_true',
             help="Execute privileges commands with sudo")
 
+    parser.add_argument('--restrict-raw', action='store_true',
+            help="Only allow raw snapshot sends")
+
     parser.set_defaults(
 
     )
@@ -172,11 +182,16 @@ def main (args):
     # run
     try:
         wrapper = Wrapper(
-            noop        = args.noop,
-            sudo        = args.sudo,
+            noop            = args.noop,
+            sudo            = args.sudo,
+            restrict_raw    = args.restrict_raw,
         )
 
         return wrapper(command_parts[0], command_parts[1:])
+
+    except Error as error:
+        log.error("%s", error)
+        return 2
 
     except Exception as error:
         log.exception("Internal error: %s", error)

--- a/bin/qmsk.zfs-ssh-command
+++ b/bin/qmsk.zfs-ssh-command
@@ -16,6 +16,7 @@ from qmsk.backup import __version__
 
 import argparse
 import contextlib
+import fnmatch
 import logging
 import os.path
 import qmsk.args
@@ -40,10 +41,11 @@ class Wrapper:
         Command wrapper
     """
 
-    def __init__(self, noop=None, sudo=None, restrict_raw=None):
+    def __init__(self, noop=None, sudo=None, restrict_raw=None, restrict_glob=None):
         self.noop = noop
         self.sudo = sudo
         self.restrict_raw = restrict_raw
+        self.restrict_glob = restrict_glob
 
     def zfs_send(self, args):
         target = args.zfs
@@ -56,6 +58,9 @@ class Wrapper:
 
         if self.restrict_raw and not args.raw:
             raise Error("Only --raw sends are allowed")
+
+        if self.restrict_glob and not any(fnmatch.fnmatch(zfs_name, pattern) for pattern in self.restrict_glob):
+            raise Error("Restricted send source: {name}".format(name=zfs_name))
 
         zfs = qmsk.backup.zfs.open(zfs_name,
             noop    = self.noop,
@@ -158,11 +163,14 @@ def main (args):
     parser.add_argument('--sudo',             action='store_true',
             help="Execute privileges commands with sudo")
 
+    parser.add_argument('--restrict-glob', action='append',
+            help="Restrict to datasets matching glob patterns")
+
     parser.add_argument('--restrict-raw', action='store_true',
             help="Only allow raw snapshot sends")
 
     parser.set_defaults(
-
+        restrict_glob = [],
     )
 
     # parse
@@ -185,6 +193,7 @@ def main (args):
             noop            = args.noop,
             sudo            = args.sudo,
             restrict_raw    = args.restrict_raw,
+            restrict_glob   = args.restrict_glob,
         )
 
         return wrapper(command_parts[0], command_parts[1:])

--- a/bin/qmsk.zfs-ssh-command
+++ b/bin/qmsk.zfs-ssh-command
@@ -85,6 +85,7 @@ class Wrapper:
                 full_incremental    = full_incremental,
                 properties          = args.properties,
                 replication_stream  = args.replication,
+                raw                 = args.raw,
             )
 
             if args.bookmark:
@@ -105,6 +106,7 @@ class Wrapper:
         parser_send.add_argument('-I', dest='incremental_full', metavar='SNAPSHOT', help="Full incremental send of all snapshots from snapshot")
         parser_send.add_argument('-p', dest='properties', action='store_true', help="Send dataset properties")
         parser_send.add_argument('-R', dest='replication', action='store_true', help="Send replication stream")
+        parser_send.add_argument('-w', dest='raw', action='store_true', help="For encrypted datasets, send data exactly as it exists on disk")
         parser_send.add_argument('zfs', metavar='ZFS', help="Source ZFS filesystem, with optional @snapshot")
         parser_send.add_argument('--bookmark', metavar='BOOKMARK', help="Bookmark snapshot after send")
         parser_send.add_argument('--purge-bookmark', metavar='BOOKMARK', help="Destroy bookmark after snapshot send")

--- a/qmsk/backup/zfs.py
+++ b/qmsk/backup/zfs.py
@@ -233,16 +233,18 @@ class Filesystem (object):
     def destroy_bookmark(self, bookmark):
         self.zfs_write('destroy', '{filesystem}#{bookmark}'.format(filesystem=self.name, bookmark=bookmark))
 
-    def receive(self, snapshot_name=None, force=None, stdin=True):
+    def receive(self, snapshot_name=None, *, force=None, properties={}, stdin=True):
         if snapshot_name:
             target = '{zfs}@{snapshot}'.format(zfs=self, snapshot=snapshot_name)
         else:
             target = self
 
+        options = ['-o{property}={value}'.format(property=key, value=value) for key, value in properties.items() if value is not None]
+
         # TODO: parse -v output to determine the received snapshot name?
         #   receiving full stream of test1/test@1 into test2/backup/test@1
         #   received 42,5KB stream in 1 seconds (42,5KB/sec)
-        self.zfs_write('receive', '-F' if force else None, target, stdin=stdin)
+        self.zfs_write('receive', '-F' if force else None, *options, target, stdin=stdin)
 
         if snapshot_name:
             return Snapshot(self, snapshot_name)

--- a/qmsk/backup/zfs.py
+++ b/qmsk/backup/zfs.py
@@ -305,7 +305,7 @@ class Snapshot (object):
     def release(self, tag):
         self.filesystem.zfs_write('release', tag, self)
 
-    def send(self, incremental=None, full_incremental=None, properties=False, replication_stream=None, stdout=True):
+    def send(self, incremental=None, full_incremental=None, properties=False, replication_stream=None, raw=None, stdout=True):
         """
             Write out ZFS contents of this snapshot to stdout.
 
@@ -318,6 +318,7 @@ class Snapshot (object):
             '-p' if properties else None,
             '-i' + str(incremental) if incremental else None,
             '-I' + str(full_incremental) if full_incremental else None,
+            '--raw' if raw else None,
             self,
             stdout=stdout,
         )

--- a/qmsk/backup/zfs.py
+++ b/qmsk/backup/zfs.py
@@ -349,7 +349,7 @@ class Source:
     def __str__(self):
         return self.source
 
-    def stream_send(self, incremental=None, full_incremental=None, properties=False, replication_stream=None, snapshot=None, bookmark=None, purge_bookmark=None):
+    def stream_send(self, raw=None, incremental=None, full_incremental=None, properties=False, replication_stream=None, snapshot=None, bookmark=None, purge_bookmark=None):
         """
             Returns a context manager.
         """
@@ -360,6 +360,7 @@ class Source:
             name += '@' + snapshot
 
         return self.invoker.stream('zfs', ['send'] + qmsk.invoke.optargs(
+            '-w' if raw else None,
             '-R' if replication_stream else None,
             '-p' if properties else None,
             '-i' + str(incremental) if incremental else None,

--- a/qmsk/backup/zfs.py
+++ b/qmsk/backup/zfs.py
@@ -314,11 +314,11 @@ class Snapshot (object):
         """
 
         self.filesystem.zfs_read('send',
+            '--raw' if raw else None, # passed as first argument to allow whitelisting `sudo /usr/sbin/zfs send --raw *`
             '-R' if replication_stream else None,
             '-p' if properties else None,
             '-i' + str(incremental) if incremental else None,
             '-I' + str(full_incremental) if full_incremental else None,
-            '--raw' if raw else None,
             self,
             stdout=stdout,
         )


### PR DESCRIPTION
Support for sending raw snapshots of encrypted datasets.

* Update `qmsk.zfs-ssh-command` to only allow raw snapshots
  * Pass through `zfs send -w` flag
  * Use `--restrict-raw` to limit sending of non-encrypted snapshots
  * Use `--restrict-glob=tank/*` to limit sending/snapshotting datasets
* Update `qmsk.backup-zfs` for raw sends
  * Use `--zfs-raw`
  * Have `zfs recv` create the (encrypted) dataset, instead of trying to receive into a dataset created with `zfs create`
* Log stderr from streaming commans on errors
  * Constructs like `ssh ... zfs send ... | zfs recv` would fail to report any errors from `ssh ... zfs send ...`, only reporting the failed `zfs recv` command