### PR TITLE
rsync restore support 

### DIFF
--- a/bin/qmsk.backup-rsync
+++ b/bin/qmsk.backup-rsync
@@ -80,10 +80,8 @@ class Target(BaseTarget):
                 **opts
         )
 
-    def __init__ (self, path, noop=None, **opts):
+    def __init__ (self, path, **opts):
         super().__init__(**opts)
-
-        self.noop = noop
 
         self.path = os.path.abspath(path)
         self.snapshots_path = os.path.join(self.path, 'snapshots')

--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -148,7 +148,7 @@ class ZFSTarget (BaseTarget):
             # rsync to local ZFS destination, and then create snapshot
             dest_path = self.mount()
 
-            log.info("%s: rsync %s@%s", self, dest_path, snapshot_name)
+            log.info("%s: rsync %s@%s <- %s", self, dest_path, snapshot_name, self.rsync_source)
 
             rsync_stats = self.rsync(dest_path)
 
@@ -231,6 +231,25 @@ class ZFSTarget (BaseTarget):
         # manage intervals
         for interval in self.intervals:
             self.backup_interval(interval, now, snapshot)
+
+    def restore (self):
+        """
+            Restore from backup to rsync source.
+        """
+
+        if self.rsync_source:
+            # rsync to local ZFS destination, and then create snapshot
+            dest_path = self.mount()
+
+            log.info("%s: rsync %s -> %s", self, dest_path, self.rsync_source)
+
+            rsync_stats = self.rsync_restore(dest_path)
+
+        elif self.zfs_source:
+            raise Error("ZFS restore is not supported for {zfs_source} source".format(zfs_source=self.zfs_source))
+
+        else:
+            raise Error("ZFS restore is not supported")
 
     def purge_interval(self, interval, snapshot_holds):
         """
@@ -349,6 +368,9 @@ def main (args):
     parser.add_argument('--purge-other-snapshots', action='store_true',
             help="Also purge other snapshots without pvl-backup:* properties")
 
+    parser.add_argument('--restore', action='store_true',
+            help="Restore from backup")
+
     parser.add_argument('target', metavar='ZFS', nargs='+',
             help="ZFS target")
 
@@ -390,14 +412,17 @@ def main (args):
                     force_source    = source if args.force_source else None,
             )
 
-            if not args.skip_backup:
-                target.backup(
-                        create          = args.setup_create,
-                )
+            if args.restore:
+                target.restore()
+            else:
+                if not args.skip_backup:
+                    target.backup(
+                            create          = args.setup_create,
+                    )
 
-            # purge intervals
-            if args.purge:
-                target.purge(other_snapshots=args.purge_other_snapshots)
+                # purge intervals
+                if args.purge:
+                    target.purge(other_snapshots=args.purge_other_snapshots)
 
         except (Error, qmsk.backup.zfs.Error) as error:
             log.exception("%s: %s", target, error)

--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -135,6 +135,20 @@ class ZFSTarget (BaseTarget):
 
         return mountpoint
 
+    def mount_snapshot(self, snapshot):
+        """
+            Return backup source path.
+        """
+
+        zfs_snapshot = self.zfs.snapshots[snapshot]
+
+        mountpoint = zfs_snapshot.mountpoint
+
+        if not mountpoint:
+            raise Error("ZFS destination is not mounted: %s", self.zfs)
+
+        return mountpoint
+
     def snapshot (self, now, create=False):
         """
             Create new ZFS snapshot for given timestamp.
@@ -232,18 +246,23 @@ class ZFSTarget (BaseTarget):
         for interval in self.intervals:
             self.backup_interval(interval, now, snapshot)
 
-    def restore (self, rsync_options={}):
+    def restore (self, snapshot=None, rsync_options={}):
         """
             Restore from backup to rsync source.
         """
 
+        if snapshot:
+            path = self.mount_snapshot(snapshot)
+        else:
+            path = self.mount()
+
         if self.rsync_source:
             # rsync directory contents from local ZFS destination
-            dest_path = self.mount() + '/'
+            path = path + '/'
 
-            log.info("%s: rsync %s -> %s", self, dest_path, self.rsync_source)
+            log.info("%s: rsync %s -> %s", self, path, self.rsync_source)
 
-            rsync_stats = self.rsync_restore(dest_path, **rsync_options)
+            rsync_stats = self.rsync_restore(path, **rsync_options)
 
         elif self.zfs_source:
             raise Error("ZFS restore is not supported for {zfs_source} source".format(zfs_source=self.zfs_source))
@@ -370,6 +389,8 @@ def main (args):
 
     parser.add_argument('--restore', action='store_true',
             help="Restore from backup")
+    parser.add_argument('--restore-snapshot', metavar='SNAPSHOT',
+            help="Restore from ZFS snapshot")
     parser.add_argument('--restore-verbose', action='store_true',
             help="Verbose output from restore")
     parser.add_argument('--restore-delete', action='store_true',
@@ -418,6 +439,8 @@ def main (args):
 
             if args.restore:
                 target.restore(
+                    snapshot    = args.restore_snapshot,
+
                     rsync_options = dict(
                         verbose     = args.restore_verbose,
                         delete      = args.restore_delete,

--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -232,7 +232,7 @@ class ZFSTarget (BaseTarget):
         for interval in self.intervals:
             self.backup_interval(interval, now, snapshot)
 
-    def restore (self):
+    def restore (self, rsync_options={}):
         """
             Restore from backup to rsync source.
         """
@@ -243,7 +243,7 @@ class ZFSTarget (BaseTarget):
 
             log.info("%s: rsync %s -> %s", self, dest_path, self.rsync_source)
 
-            rsync_stats = self.rsync_restore(dest_path)
+            rsync_stats = self.rsync_restore(dest_path, **rsync_options)
 
         elif self.zfs_source:
             raise Error("ZFS restore is not supported for {zfs_source} source".format(zfs_source=self.zfs_source))
@@ -370,6 +370,10 @@ def main (args):
 
     parser.add_argument('--restore', action='store_true',
             help="Restore from backup")
+    parser.add_argument('--restore-verbose', action='store_true',
+            help="Verbose output from restore")
+    parser.add_argument('--restore-delete', action='store_true',
+            help="Delete any extra files present on the source when restoring")
 
     parser.add_argument('target', metavar='ZFS', nargs='+',
             help="ZFS target")
@@ -413,7 +417,12 @@ def main (args):
             )
 
             if args.restore:
-                target.restore()
+                target.restore(
+                    rsync_options = dict(
+                        verbose     = args.restore_verbose,
+                        delete      = args.restore_delete,
+                    ),
+                )
             else:
                 if not args.skip_backup:
                     target.backup(

--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -262,7 +262,7 @@ class ZFSTarget (BaseTarget):
 
             log.info("%s: rsync %s -> %s", self, path, self.rsync_source)
 
-            rsync_stats = self.rsync_restore(path, **rsync_options)
+            self.rsync_restore(path, **rsync_options)
 
         elif self.zfs_source:
             raise Error("ZFS restore is not supported for {zfs_source} source".format(zfs_source=self.zfs_source))

--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -238,8 +238,8 @@ class ZFSTarget (BaseTarget):
         """
 
         if self.rsync_source:
-            # rsync to local ZFS destination, and then create snapshot
-            dest_path = self.mount()
+            # rsync directory contents from local ZFS destination
+            dest_path = self.mount() + '/'
 
             log.info("%s: rsync %s -> %s", self, dest_path, self.rsync_source)
 

--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -32,7 +32,7 @@ class ZFSTarget (BaseTarget):
 
     @classmethod
     def config (cls, name,
-            noop        = None,
+            noop            = None,
             zfs_source      = None,
             zfs_raw         = None,
             zfs_bookmark    = None,
@@ -54,6 +54,7 @@ class ZFSTarget (BaseTarget):
                 zfs_source      = zfs_source,
                 zfs_raw         = zfs_raw,
                 zfs_bookmark    = zfs_bookmark,
+                noop            = noop,
                 **opts
         )
 

--- a/bin/qmsk.rsync-ssh-command
+++ b/bin/qmsk.rsync-ssh-command
@@ -41,7 +41,11 @@ def rsync_wrapper (args, command, server=False):
         return 2
 
     if args.readonly and not sender:
-        log.error("Invalid rsync command %r: restricted to --sender mode", command)
+        log.error("Invalid rsync command %r: --readonly restricts to rsync --server --sender mode only", command)
+        return 2
+
+    if not sender and not args.allow_restore:
+        log.error("Invalid rsync command %r: rsync --server mode is restricted without --allow-restore", command)
         return 2
 
     # parse source path
@@ -111,6 +115,9 @@ def main (args):
 
     parser.add_argument('--allow-remote',     action='store_true', default=False,
             help="Allow remote rsync sources")
+
+    parser.add_argument('--allow-restore',    action='store_true', default=False,
+            help="Allow rsync --server write mode")
 
     # lvm options
     parser.add_argument('-L', '--snapshot-size', metavar='SIZE', default=lvm.LVM_SNAPSHOT_SIZE,

--- a/bin/qmsk.rsync-ssh-command
+++ b/bin/qmsk.rsync-ssh-command
@@ -6,9 +6,9 @@
     Testing:
         virtualenv opt && ./opt/bin/pip install -e
 
-        sudo SSH_ORIG_COMMAND='rsync --server --sender -ax . lvm:asdf:test' ./opt/bin/qmsk.backup-rsync -v
+        sudo SSH_ORIG_COMMAND='rsync --server --sender -ax . lvm:asdf:test' ./opt/bin/qmsk.rsync-ssh-command -v
 
-        sudo rsync -e './opt/bin/qmsk.backup-rsync --debug --' -ax testing:lvm:asdf:test test/tmp"
+        sudo rsync -e './opt/bin/qmsk.rsync-ssh-command --debug --' -ax testing:lvm:asdf:test test/tmp
 """
 
 import logging
@@ -35,42 +35,51 @@ def rsync_wrapper (args, command, server=False):
 
     # parse --sender command
     try :
-        rsync_options, source_path = qmsk.backup.rsync.parse_sender_command(command)
+        rsync_options, path, sender = qmsk.backup.rsync.parse_server_command(command)
     except qmsk.backup.rsync.CommandError as error:
         log.error("Invalid rsync command %r: %s", command, error)
         return 2
-    
+
+    if args.readonly and not sender:
+        log.error("Invalid rsync command %r: restricted to --sender mode", command)
+        return 2
+
     # parse source path
     try :
-        rsync_source = qmsk.backup.rsync.parse_source(source_path,
+        rsync_source = qmsk.backup.rsync.parse_source(path,
                 restrict_paths      = args.restrict_path,
                 allow_remote        = args.allow_remote,
                 sudo                = args.sudo,
                 lvm_opts            = dict(
-                    size    = args.snapshot_size, 
+                    size    = args.snapshot_size,
                     wait    = args.snapshot_wait,
                     retry   = args.snapshot_retry,
                 ),
             )
 
     except qmsk.backup.rsync.SourceError as error:
-        log.error("Invalid rsync source: %r: %s", source_path, error)
+        log.error("Invalid rsync source: %r: %s", path, error)
         return 2
 
     # noop?
     if args.noop:
-        log.info("noop: %r -> %r: execute(%r, %r)", path, source, rsync_options, srcdst)
+        log.info("noop: %r -> rsync %s", path, ' '.join(rsync_options + ['.', source]))
         return 0
 
     # execute
     try:
-        # run rsync within the source (may perform additional stuff like snapshot...)
-        rsync_source.rsync_sender(rsync_options)
+        if sender:
+            # run rsync --server --sender within the source (may perform additional stuff like snapshot...)
+            rsync_source.rsync_sender(rsync_options)
+
+        else:
+            # run rsync --server within the source
+            rsync_source.rsync_server(rsync_options)
 
     except qmsk.invoke.InvokeError as error:
         log.error("rsync failed: %s", error)
         return error.exit
-    
+
     else:
         log.debug("rsync ok")
 
@@ -99,7 +108,7 @@ def main (args):
 
     parser.add_argument('--sudo',             action='store_true',
             help="Execute rsync under sudo")
-    
+
     parser.add_argument('--allow-remote',     action='store_true', default=False,
             help="Allow remote rsync sources")
 
@@ -126,7 +135,7 @@ def main (args):
 
     # parse
     args = qmsk.args.parse(parser, args)
-    
+
     # from args (as given by `rsync -e qmsk.backup-rsync`) -> 'qmsk.backup-rsync <host> (<command> ...)'
     if args.ssh_command:
         # from ssh authorized_keys command="..."
@@ -137,7 +146,7 @@ def main (args):
         command_parts = args.rsync_command
 
         log.debug("host=%r, using command from args: %r", host, command_parts)
-    
+
     else:
         log.error("No rsync command given")
         return 2

--- a/qmsk/backup/mount.py
+++ b/qmsk/backup/mount.py
@@ -84,7 +84,7 @@ class Mount (object) :
         """
             Test if the given mountpoint is mounted.
         """
-        
+
         # workaround http://bugs.python.org/issue2466
         if os.path.exists(self.mnt) and not os.path.exists(os.path.join(self.mnt, '.')) :
             # this is a sign of a mountpoint that we do not have access to
@@ -131,7 +131,7 @@ def mount (dev, mnt=None, name_hint='tmp', **kwargs) :
 
     else :
         tmpdir = None
-        
+
     log.debug("mount: %s -> %s", dev, mnt)
 
     # with tempdir
@@ -170,7 +170,7 @@ def mounts():
 
     for line in open('/proc/mounts'):
         parts = line.split()
-        
+
         dev = parts[0]
         mount = parts[1]
         fstype = parts[2]
@@ -179,7 +179,7 @@ def mounts():
 
 def find (path):
     """
-        Find mount point for given file path.
+        Find mount for given file path.
 
         Returns (device path, mount path, fstype, file path)
     """
@@ -192,7 +192,7 @@ def find (path):
         name = os.path.join(basename, name)
 
         log.debug("%s / %s", path, name)
-        
+
     # find mount
     for device, mount, fstype in mounts():
         if mount == path:

--- a/qmsk/backup/rsync.py
+++ b/qmsk/backup/rsync.py
@@ -260,11 +260,11 @@ class Source (object):
 
     def rsync_restore (self, options, dest):
         """
-            Run from given destination to restore path, returning optional stats dict.
+            Run from given destination to restore path.
         """
 
         with self.mount_restore() as path:
-            return rsync(options, [dest, path], sudo=self.sudo)
+            rsync(options, [dest, path], sudo=self.sudo)
 
     def __str__ (self):
         return self.path

--- a/qmsk/backup/rsync.py
+++ b/qmsk/backup/rsync.py
@@ -149,6 +149,17 @@ def print_stats(rows):
 
 def rsync (options, paths, sudo=False):
     """
+        Run rsync, passing through stdout.
+
+        Raises qmsk.invoke.InvokeError
+    """
+
+    log.info("rsync %s %s", ' '.join(options), ' '.join(paths))
+
+    stdout = qmsk.invoke.invoke(RSYNC, options + paths, sudo=sudo, stdout=True)
+
+def rsync_stats (options, paths, sudo=False):
+    """
         Run rsync.
 
         Returns a stats dict if there is any valid --stats output, None otherwise.
@@ -245,7 +256,7 @@ class Source (object):
         """
 
         with self.mount_snapshot() as path:
-            return rsync(options, [path, dest], sudo=self.sudo)
+            return rsync_stats(options, [path, dest], sudo=self.sudo)
 
     def rsync_restore (self, options, dest):
         """

--- a/qmsk/backup/rsync.py
+++ b/qmsk/backup/rsync.py
@@ -371,7 +371,7 @@ class ZFSSource(Source):
             Return local filesystem path for rsync dest.
         """
 
-        raise NotImplementedError("No restore support for zfs sources")
+        raise SourceError("No restore support for zfs sources")
 
     def __str__ (self):
         return 'zfs:{zfs}'.format(zfs=self.zfs)

--- a/qmsk/backup/rsync.py
+++ b/qmsk/backup/rsync.py
@@ -416,8 +416,8 @@ def parse_server_command(command):
 
         Returns:
             options:    list of --options and -opts from parse_options
-            source:     source path if sender, or None
-            dest:       dest path if receiver, or None
+            path:       source path if sender, dest path if server
+            sender:     True if sender, False if server
 
         Raises:
             CommandError
@@ -429,50 +429,25 @@ def parse_server_command(command):
     if cmd.split('/')[-1] != 'rsync':
         raise CommandError("Invalid command: {cmd}".format(cmd=cmd))
 
+    if not '--server' in options:
+        raise CommandError("Missing --server")
+
     if len(args) != 2:
         raise CommandError("Invalid source/destination paths")
 
     if args[0] != '.':
         raise CommandError("Invalid source-path for server")
 
+    # parse real source
     path = args[1]
 
-    # parse real source
-    if not '--server' in options:
-        raise CommandError("Missing --server")
-
-    elif not '--sender' in options:
-        # write
-        source = None
-        dest = path
-
-    else:
-        # read
-        source = path
-        dest = None
+    if '--sender' in options:
+        sender = True
+    else :
+        sender = False
 
     # ok
-    return options, source, dest
-
-def parse_sender_command (command):
-    """
-        Parse rsync's internal --server --sender command used when reading over SSH.
-
-        Returns:
-            options:    list of --options and -opts from parse_options
-            source:     source path
-
-        Raises:
-            CommandError
-
-    """
-
-    options, source, dest = parse_server_command(command)
-
-    if dest:
-        raise CommandError("Missing --sender")
-    else:
-        return options, source
+    return options, path, sender
 
 def parse_source (path, restrict_paths=None, allow_remote=True, sudo=None, lvm_opts={}):
     """

--- a/qmsk/backup/rsync.py
+++ b/qmsk/backup/rsync.py
@@ -309,7 +309,7 @@ class LVMSource(Source):
             Return local filesystem path for rsync dest.
         """
 
-        raise NotImplementedError()
+        raise NotImplementedError("No restore support for lvm sources")
 
     def __str__ (self):
         return 'lvm:{volume}'.format(volume=self.lvm_volume)
@@ -364,7 +364,7 @@ class ZFSSource(Source):
             Return local filesystem path for rsync dest.
         """
 
-        raise NotImplementedError()
+        raise NotImplementedError("No restore support for zfs sources")
 
     def __str__ (self):
         return 'zfs:{zfs}'.format(zfs=self.zfs)

--- a/qmsk/backup/rsync.py
+++ b/qmsk/backup/rsync.py
@@ -309,7 +309,14 @@ class LVMSource(Source):
             Return local filesystem path for rsync dest.
         """
 
-        raise NotImplementedError("No restore support for lvm sources")
+        dev = self.lvm_volume.dev
+
+        try:
+            device, mount, fstype = qmsk.backup.mount.find_dev(dev)
+        except FileNotFoundError:
+            raise SourceError("LVM {lvm} is not mounted for restore".format(lvm=self.lvm_volume))
+        else:
+            yield mount.rstrip('/') + '/' + self.path
 
     def __str__ (self):
         return 'lvm:{volume}'.format(volume=self.lvm_volume)

--- a/qmsk/backup/target.py
+++ b/qmsk/backup/target.py
@@ -211,6 +211,36 @@ class BaseTarget:
         else:
             return stats
 
+    def rsync_restore (self, path):
+        """
+            rsync given path to source.
+
+            Return the --stats dict, or None if unparseable.
+
+            Raises qmsk.backup.rsync.Error
+        """
+
+        rsync_options = dict(self.rsync_options)
+
+        # use stats
+        rsync_options['stats'] = True
+
+        if self.noop:
+            rsync_options['dry-run'] = True
+
+        opts = qmsk.invoke.optargs(**rsync_options)
+
+        try:
+            # run the rsync.RSyncServer; None as a placeholder will get replaced with the actual source
+            stats = self.rsync_source.rsync_restore(opts, path)
+
+        except qmsk.backup.rsync.Error as error:
+            log.warn("%s rsync error: %s", self, error)
+            raise
+
+        else:
+            return stats
+
     def snapshot (self, now):
         """
             Update the current snapshot to point to a new snapshot for the given datetime, containing changes from rsync.

--- a/qmsk/backup/target.py
+++ b/qmsk/backup/target.py
@@ -211,19 +211,15 @@ class BaseTarget:
         else:
             return stats
 
-    def rsync_restore (self, path):
+    def rsync_restore (self, path, **options):
         """
             rsync given path to source.
-
-            Return the --stats dict, or None if unparseable.
 
             Raises qmsk.backup.rsync.Error
         """
 
         rsync_options = dict(self.rsync_options)
-
-        # use stats
-        rsync_options['stats'] = True
+        rsync_options.update(options)
 
         if self.noop:
             rsync_options['dry-run'] = True
@@ -231,7 +227,6 @@ class BaseTarget:
         opts = qmsk.invoke.optargs(**rsync_options)
 
         try:
-            # run the rsync.RSyncServer; None as a placeholder will get replaced with the actual source
             stats = self.rsync_source.rsync_restore(opts, path)
 
         except qmsk.backup.rsync.Error as error:

--- a/qmsk/backup/target.py
+++ b/qmsk/backup/target.py
@@ -227,14 +227,11 @@ class BaseTarget:
         opts = qmsk.invoke.optargs(**rsync_options)
 
         try:
-            stats = self.rsync_source.rsync_restore(opts, path)
+            self.rsync_source.rsync_restore(opts, path)
 
         except qmsk.backup.rsync.Error as error:
             log.warn("%s rsync error: %s", self, error)
             raise
-
-        else:
-            return stats
 
     def snapshot (self, now):
         """

--- a/qmsk/backup/zfs.py
+++ b/qmsk/backup/zfs.py
@@ -270,6 +270,16 @@ class Snapshot (object):
     def __str__ (self):
         return '{filesystem}@{name}'.format(name=self.name, filesystem=self.filesystem)
 
+
+    @property
+    def mountpoint(self):
+        mountpoint = self.filesystem.mountpoint
+
+        if mountpoint:
+            return '{mountpoint}/.zfs/snapshot/{snapshot}'.format(mountpoint=mountpoint, snapshot=self.name)
+        else:
+            return None
+
     # TODO: default to properties=None to explode if not set?
     def __getitem__ (self, name):
         return self.properties[name]


### PR DESCRIPTION
Implement support for ZFS -> rsync restores using `qmsk.backup-zfs --restore` with `qmsk.rsync-ssh-command --allow-restore`.

* Extend `qmsk.rsync-ssh-command` to support both `rsync --server` and `rsync --server --sender`
  * Previously the `--readonly` flag did nothing, only `rsync --server --sender` was supported
  * Add new `--allow-restore` flag to make the new default behavior match the existing default behavior without `--readonly`
* Extend rsync sources to support restore operations
  * Run `rsync --server` against the mounted filesystem
  * Resolve `lvm:VG/LV/path` to the LVM device mountpoint + path
  * No support for `zfs:...` yet
* Fix `qmsk.backup.zfs --noop` to use `rsync --dry-run`
  * Previously only the ZFS operations were noop'd, the rsync operations were still run
* Add `qmsk.backup-zfs --restore`
  * Only supported for `--rsync-source`
  * Run rsync from ZFS dataset root directory -> rsync source
  * Requires remote rsync source to accept `rsync --server`
  * Use `--restore-snapshot=...` to rsync from a specific ZFS snapshot
  * Use `--restore-verbose` to list restored files
  * Use `--restore-delete` to delete extra files