### PR TITLE
qmsk.zfs-backup --ignore-source-mismatch

### DIFF
--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -80,7 +80,7 @@ class ZFSTarget (BaseTarget):
             'qmsk-backup:source': source,
         })
 
-    def setup (self, create=False, verify_source=None, force_source=False):
+    def setup (self, create=False, create_source=None, verify_source=None, force_source=False):
         """
             Verify that the ZFS volume exists.
         """
@@ -101,7 +101,7 @@ class ZFSTarget (BaseTarget):
 
             elif self.rsync_source:
                 # create for mount/rsync
-                self.create(verify_source)
+                self.create(create_source)
 
             elif self.zfs_source:
                 # will be created by zfs recv
@@ -433,6 +433,7 @@ def main (args):
 
             target.setup(
                     create          = args.setup_create,
+                    create_source   = source,
                     verify_source   = source,
                     force_source    = source if args.force_source else None,
             )

--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -363,6 +363,8 @@ def main (args):
 
     parser.add_argument('--force-source', action='store_true',
             help="Update ZFS rsync source")
+    parser.add_argument('--ignore-source-mismatch', action='store_true',
+            help="Ignore ZFS rsync source mismatch")
     parser.add_argument('--rsync-source', metavar='RSYNC-SOURCE',
             help="Backup rsync source")
     parser.add_argument('--rsync-option', metavar='-option', action='append', dest='rsync_options', default=[],
@@ -431,10 +433,15 @@ def main (args):
             else:
                 source = None
 
+            if args.ignore_source_mismatch:
+                verify_source = None
+            else:
+                verify_source = source
+
             target.setup(
                     create          = args.setup_create,
                     create_source   = source,
-                    verify_source   = source,
+                    verify_source   = verify_source,
                     force_source    = source if args.force_source else None,
             )
 


### PR DESCRIPTION
Useful for `--restore` to different source