### PR TITLE
Support zfs send --compressed

### DIFF
--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -35,6 +35,7 @@ class ZFSTarget (BaseTarget):
             noop            = None,
             zfs_source      = None,
             zfs_raw         = None,
+            zfs_compressed  = None,
             zfs_bookmark    = None,
             invoker_options = {},
             ssh_options     = {},
@@ -52,18 +53,21 @@ class ZFSTarget (BaseTarget):
                     invoker = qmsk.invoke.Invoker(**invoker_options),
                 ),
                 zfs_source      = zfs_source,
-                zfs_raw         = zfs_raw,
+                zfs_send_options = dict(
+                    raw         = zfs_raw,
+                    compressed  = zfs_compressed,
+                ),
                 zfs_bookmark    = zfs_bookmark,
                 noop            = noop,
                 **opts
         )
 
-    def __init__ (self, zfs, zfs_source=None, zfs_raw=None, zfs_bookmark=None, **opts):
+    def __init__ (self, zfs, zfs_source=None, zfs_send_options={}, zfs_bookmark=None, **opts):
         super(ZFSTarget, self).__init__(**opts)
 
         self.zfs = zfs
         self.zfs_source = zfs_source
-        self.zfs_raw = zfs_raw
+        self.zfs_send_options = zfs_send_options
         self.zfs_bookmark = zfs_bookmark
 
     def __str__ (self):
@@ -190,11 +194,11 @@ class ZFSTarget (BaseTarget):
             send_bookmark = self.zfs_bookmark + ':' + snapshot_name
 
             with self.zfs_source.stream_send(
-                raw             = self.zfs_raw,
                 incremental     = '#' + incremental_bookmark if incremental_bookmark else None,
                 snapshot        = None, # create temporary snapshot
                 bookmark        = send_bookmark, # create bookmark for sent snapshot
                 purge_bookmark  = incremental_bookmark, # destroy bookmark for incremental snapshot
+                **self.zfs_send_options
             ) as stream:
                 # create new snapshot with desired name
                 # implicitly creates dataset if missing
@@ -375,6 +379,8 @@ def main (args):
             help="ZFS send/recv from SSH remote or local pool")
     parser.add_argument('--zfs-raw', action='store_true',
             help="ZFS send --raw of encrypted dataset")
+    parser.add_argument('--zfs-compressed', action='store_true',
+            help="ZFS send --compressed of compressed dataset")
     parser.add_argument('--zfs-bookmark', metavar='BOOKMARK-PREFIX', default=ZFS_BOOKMARK,
             help="Sender bookmark prefix")
     parser.add_argument('--ssh-config', metavar='PATH')
@@ -410,6 +416,7 @@ def main (args):
                     rsync_options   = args.rsync_options,
                     zfs_source      = args.zfs_source,
                     zfs_raw         = args.zfs_raw,
+                    zfs_compressed  = args.zfs_compressed,
                     zfs_bookmark    = args.zfs_bookmark,
                     invoker_options = dict(
                         sudo            = args.sudo,

--- a/bin/qmsk.zfs-ssh-command
+++ b/bin/qmsk.zfs-ssh-command
@@ -98,6 +98,9 @@ class Wrapper:
                 properties          = args.properties,
                 replication_stream  = args.replication,
                 raw                 = args.raw,
+                compressed          = args.compressed,
+                large_block         = args.large_block,
+                dedup               = args.dedup,
             )
 
             if args.bookmark:
@@ -119,6 +122,9 @@ class Wrapper:
         parser_send.add_argument('-p', dest='properties', action='store_true', help="Send dataset properties")
         parser_send.add_argument('-R', dest='replication', action='store_true', help="Send replication stream")
         parser_send.add_argument('-w', dest='raw', action='store_true', help="For encrypted datasets, send data exactly as it exists on disk")
+        parser_send.add_argument('-c', dest='compressed', action='store_true', help="For compressed datasets, send compresssed blocks from disk")
+        parser_send.add_argument('-L', dest='large_block', action='store_true', help="Generate a stream which may contain blocks larger than 128KB")
+        parser_send.add_argument('-D', dest='dedup', action='store_true', help="Generate a deduplicated stream")
         parser_send.add_argument('zfs', metavar='ZFS', help="Source ZFS filesystem, with optional @snapshot")
         parser_send.add_argument('--bookmark', metavar='BOOKMARK', help="Bookmark snapshot after send")
         parser_send.add_argument('--purge-bookmark', metavar='BOOKMARK', help="Destroy bookmark after snapshot send")

--- a/qmsk/backup/zfs.py
+++ b/qmsk/backup/zfs.py
@@ -317,7 +317,7 @@ class Snapshot (object):
     def release(self, tag):
         self.filesystem.zfs_write('release', tag, self)
 
-    def send(self, incremental=None, full_incremental=None, properties=False, replication_stream=None, raw=None, stdout=True):
+    def send(self, incremental=None, full_incremental=None, properties=False, replication_stream=None, raw=None, compressed=None, large_block=None, dedup=None, stdout=True):
         """
             Write out ZFS contents of this snapshot to stdout.
 
@@ -327,6 +327,9 @@ class Snapshot (object):
 
         self.filesystem.zfs_read('send',
             '--raw' if raw else None, # passed as first argument to allow whitelisting `sudo /usr/sbin/zfs send --raw *`
+            '-c' if compressed else None,
+            '-L' if large_block else None,
+            '-D' if dedup else None,
             '-R' if replication_stream else None,
             '-p' if properties else None,
             '-i' + str(incremental) if incremental else None,
@@ -361,7 +364,7 @@ class Source:
     def __str__(self):
         return self.source
 
-    def stream_send(self, raw=None, incremental=None, full_incremental=None, properties=False, replication_stream=None, snapshot=None, bookmark=None, purge_bookmark=None):
+    def stream_send(self, raw=None, compressed=None, large_block=None, dedup=None, incremental=None, full_incremental=None, properties=False, replication_stream=None, snapshot=None, bookmark=None, purge_bookmark=None):
         """
             Returns a context manager.
         """
@@ -373,6 +376,9 @@ class Source:
 
         return self.invoker.stream('zfs', ['send'] + qmsk.invoke.optargs(
             '-w' if raw else None,
+            '-c' if compressed else None,
+            '-L' if large_block else None,
+            '-D' if dedup else None,
             '-R' if replication_stream else None,
             '-p' if properties else None,
             '-i' + str(incremental) if incremental else None,


### PR DESCRIPTION
Using `zfs send` with compressed datasets requires 'zfs send --compressed`.