### PR TITLE
ZFS restore support

### DIFF
--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -250,17 +250,17 @@ class ZFSTarget (BaseTarget):
         for interval in self.intervals:
             self.backup_interval(interval, now, snapshot)
 
-    def restore (self, snapshot=None, rsync_options={}):
+    def restore (self, snapshot=None, rsync_options={}, zfs_options=None):
         """
             Restore from backup to rsync source.
         """
 
-        if snapshot:
-            path = self.mount_snapshot(snapshot)
-        else:
-            path = self.mount()
-
         if self.rsync_source:
+            if snapshot:
+                path = self.mount_snapshot(snapshot)
+            else:
+                path = self.mount()
+
             # rsync directory contents from local ZFS destination
             path = path + '/'
 
@@ -269,7 +269,16 @@ class ZFSTarget (BaseTarget):
             self.rsync_restore(path, **rsync_options)
 
         elif self.zfs_source:
-            raise Error("ZFS restore is not supported for {zfs_source} source".format(zfs_source=self.zfs_source))
+            if snapshot:
+                zfs_snapshot = self.zfs.snapshots[snapshot]
+            else:
+                # send from last snapshot, not filesystem - sending from filesystem requires it to be unmounted
+                zfs_snapshot = self.zfs.last_snapshot()
+
+            log.info("%s: zfs %s -> %s", self, zfs_snapshot, self.zfs_source)
+
+            with self.zfs_source.stream_receive(**zfs_options) as stream:
+                zfs_snapshot.send(stdout=stream, **self.zfs_send_options)
 
         else:
             raise Error("ZFS restore is not supported")
@@ -403,6 +412,8 @@ def main (args):
             help="Verbose output from restore")
     parser.add_argument('--restore-delete', action='store_true',
             help="Delete any extra files present on the source when restoring")
+    parser.add_argument('--zfs-restore-force', action='store_true',
+            help="Use zfs recv -F to force rollback the target dataset for the restore. Destroys any changes on the source, only requires if restored dataset already exists.")
 
     parser.add_argument('target', metavar='ZFS', nargs='+',
             help="ZFS target")
@@ -460,6 +471,9 @@ def main (args):
                         verbose     = args.restore_verbose,
                         delete      = args.restore_delete,
                     ),
+                    zfs_options = dict(
+                        force       = args.zfs_restore_force,
+                    )
                 )
             else:
                 if not args.skip_backup:

--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -410,7 +410,7 @@ def main (args):
             help="Restore from ZFS snapshot")
     parser.add_argument('--restore-verbose', action='store_true',
             help="Verbose output from restore")
-    parser.add_argument('--restore-delete', action='store_true',
+    parser.add_argument('--rsync-restore-delete', action='store_true',
             help="Delete any extra files present on the source when restoring")
     parser.add_argument('--zfs-restore-force', action='store_true',
             help="Use zfs recv -F to force rollback the target dataset for the restore. Destroys any changes on the source, only requires if restored dataset already exists.")
@@ -469,7 +469,7 @@ def main (args):
 
                     rsync_options = dict(
                         verbose     = args.restore_verbose,
-                        delete      = args.restore_delete,
+                        delete      = args.rsync_restore_delete,
                     ),
                     zfs_options = dict(
                         force       = args.zfs_restore_force,

--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -277,8 +277,8 @@ class ZFSTarget (BaseTarget):
 
             log.info("%s: zfs %s -> %s", self, zfs_snapshot, self.zfs_source)
 
-            with self.zfs_source.stream_receive(**zfs_options) as stream:
-                zfs_snapshot.send(stdout=stream, **self.zfs_send_options)
+            with zfs_snapshot.stream_send(**self.zfs_send_options) as stream:
+                self.zfs_source.receive(stdin=stream, **zfs_options)
 
         else:
             raise Error("ZFS restore is not supported")

--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -473,6 +473,8 @@ def main (args):
                     ),
                     zfs_options = dict(
                         force       = args.zfs_restore_force,
+                        noop        = args.noop,
+                        verbose     = args.restore_verbose,
                     )
                 )
             else:

--- a/bin/qmsk.zfs-ssh-command
+++ b/bin/qmsk.zfs-ssh-command
@@ -77,6 +77,8 @@ class Wrapper:
         zfs.receive(
             snapshot_name   = snapshot_name,
             force           = args.receive_force,
+            noop            = args.receive_noop,
+            verbose         = args.receive_verbose,
             stdin           = True, # passthrough
         )
 
@@ -166,6 +168,8 @@ class Wrapper:
 
         parser_recv = subparsers.add_parser('receive', aliases=['recv'])
         parser_recv.add_argument('-F', dest='receive_force', action='store_true', help="Force a rollback of the file system to the most recent snapshot before performing the receive operation.")
+        parser_recv.add_argument('-n', dest='receive_noop', action='store_true', help="Do not actually receive the stream.")
+        parser_recv.add_argument('-v', dest='receive_verbose', action='store_true', help="Print verbose information about the stream and the time required to perform the receive operation.")
         parser_recv.add_argument('zfs', metavar='ZFS', help="Destination ZFS filesystem, with optional @snapshot")
 
         args = parser.parse_args(args)

--- a/bin/qmsk.zfs-ssh-command
+++ b/bin/qmsk.zfs-ssh-command
@@ -41,11 +41,46 @@ class Wrapper:
         Command wrapper
     """
 
-    def __init__(self, noop=None, sudo=None, restrict_raw=None, restrict_glob=None):
+    def __init__(self, noop=None, sudo=None, restrict_raw=None, restrict_glob=None, allow_receive=None, allow_force_receive=None):
         self.noop = noop
         self.sudo = sudo
         self.restrict_raw = restrict_raw
         self.restrict_glob = restrict_glob
+        self.allow_receive = allow_receive
+        self.allow_force_receive = allow_force_receive
+
+    def zfs_receive(self, args):
+        target = args.zfs
+
+        if '@' in target:
+            zfs_name, snapshot_name = target.split('@', 1)
+        else:
+            zfs_name = target
+            snapshot_name = None
+
+        if not self.allow_receive:
+            raise Error("Restricted recv operation")
+
+        if args.receive_force and not self.allow_force_receive:
+            raise Error("Restricted recv -F operation")
+
+        if self.restrict_glob and not any(fnmatch.fnmatch(zfs_name, pattern) for pattern in self.restrict_glob):
+            raise Error("Restricted send source: {name}".format(name=zfs_name))
+
+        zfs = qmsk.backup.zfs.open(zfs_name,
+            noop    = self.noop,
+            invoker = qmsk.invoke.Invoker(sudo=self.sudo),
+        )
+
+        log.info("zfs recv %s with snapshot=%s, force=%s", zfs, snapshot_name, args.receive_force)
+
+        zfs.receive(
+            snapshot_name   = snapshot_name,
+            force           = args.receive_force,
+            stdin           = True, # passthrough
+        )
+
+        return 0
 
     def zfs_send(self, args):
         target = args.zfs
@@ -129,10 +164,16 @@ class Wrapper:
         parser_send.add_argument('--bookmark', metavar='BOOKMARK', help="Bookmark snapshot after send")
         parser_send.add_argument('--purge-bookmark', metavar='BOOKMARK', help="Destroy bookmark after snapshot send")
 
+        parser_recv = subparsers.add_parser('receive', aliases=['recv'])
+        parser_recv.add_argument('-F', dest='receive_force', action='store_true', help="Force a rollback of the file system to the most recent snapshot before performing the receive operation.")
+        parser_recv.add_argument('zfs', metavar='ZFS', help="Destination ZFS filesystem, with optional @snapshot")
+
         args = parser.parse_args(args)
 
         if args.command == 'send':
             return self.zfs_send(args)
+        elif args.command == 'receive' or args.command == 'recv':
+            return self.zfs_receive(args)
         else:
             log.error("Unsupported ZFS command: %s", args.command)
             return 1
@@ -175,6 +216,12 @@ def main (args):
     parser.add_argument('--restrict-raw', action='store_true',
             help="Only allow raw snapshot sends")
 
+    parser.add_argument('--allow-receive', '--allow-recv', action='store_true',
+            help="Also allow zfs recv for restore operations. The --restrict-glob still applies.")
+
+    parser.add_argument('--allow-force-receive', '--allow-force-recv', action='store_true',
+            help="Also allow zfs recv -F for restore operations. Does NOT imply --allow-receive.")
+
     parser.set_defaults(
         restrict_glob = [],
     )
@@ -200,6 +247,9 @@ def main (args):
             sudo            = args.sudo,
             restrict_raw    = args.restrict_raw,
             restrict_glob   = args.restrict_glob,
+
+            allow_receive       = args.allow_receive,
+            allow_force_receive = args.allow_force_receive,
         )
 
         return wrapper(command_parts[0], command_parts[1:])

--- a/bin/qmsk.zfs-ssh-command
+++ b/bin/qmsk.zfs-ssh-command
@@ -65,7 +65,7 @@ class Wrapper:
             raise Error("Restricted recv -F operation")
 
         if self.restrict_glob and not any(fnmatch.fnmatch(zfs_name, pattern) for pattern in self.restrict_glob):
-            raise Error("Restricted send source: {name}".format(name=zfs_name))
+            raise Error("Restricted recv source: {name}".format(name=zfs_name))
 
         zfs = qmsk.backup.zfs.Filesystem(zfs_name,
             noop    = self.noop,

--- a/bin/qmsk.zfs-ssh-command
+++ b/bin/qmsk.zfs-ssh-command
@@ -67,7 +67,7 @@ class Wrapper:
         if self.restrict_glob and not any(fnmatch.fnmatch(zfs_name, pattern) for pattern in self.restrict_glob):
             raise Error("Restricted send source: {name}".format(name=zfs_name))
 
-        zfs = qmsk.backup.zfs.open(zfs_name,
+        zfs = qmsk.backup.zfs.Filesystem(zfs_name,
             noop    = self.noop,
             invoker = qmsk.invoke.Invoker(sudo=self.sudo),
         )

--- a/qmsk/backup/zfs.py
+++ b/qmsk/backup/zfs.py
@@ -432,7 +432,7 @@ class Source:
             purge_bookmark = purge_bookmark,
         ))
 
-    def _receive_opts(self, snapshot=None, force=None):
+    def _receive_opts(self, snapshot=None, force=None, noop=None, verbose=None):
         name = self.zfs_name
 
         if snapshot:
@@ -440,6 +440,8 @@ class Source:
 
         return qmsk.invoke.optargs(
             '-F' if force else None,
+            '-n' if noop else None,
+            '-v' if verbose else None,
 
             name,
         )

--- a/qmsk/backup/zfs.py
+++ b/qmsk/backup/zfs.py
@@ -366,7 +366,7 @@ class Source:
 
     def stream_send(self, raw=None, compressed=None, large_block=None, dedup=None, incremental=None, full_incremental=None, properties=False, replication_stream=None, snapshot=None, bookmark=None, purge_bookmark=None):
         """
-            Returns a context manager.
+            Returns a context manager for the send stream.
         """
 
         name = self.zfs_name
@@ -389,4 +389,20 @@ class Source:
             # custom qmsk.backup-ssh-command extensions
             bookmark = bookmark,
             purge_bookmark = purge_bookmark,
+        ))
+
+    def stream_receive(self, snapshot=None, force=None):
+        """
+            Returns a context manager for the recv stream.
+        """
+
+        name = self.zfs_name
+
+        if snapshot:
+            name += '@' + snapshot
+
+        return self.invoker.stream('zfs', ['receive'] + qmsk.invoke.optargs(
+            '-F' if force else None,
+
+            name,
         ))

--- a/qmsk/invoke.py
+++ b/qmsk/invoke.py
@@ -95,6 +95,9 @@ def invoke (cmd, args, stdin=None, stdout=None, quiet=False, setenv=None, sudo=F
     elif stdout is False:
         # discard
         popen_stdout = subprocess.DEVNULL
+    else:
+        # stdout from given open file
+        popen_stdout = stdout
 
     if setenv:
         env = dict(os.environ)


### PR DESCRIPTION
* Add `qmsk.zfs-ssh-command` `zfs recv` support
  * Requires `--allow-receive` for `zfs recv`
  * Requires `--allow-force-receive` for `zfs recv -F` 
  * Supports `-n` and `-v` for testing restores
* Add `qmsk.backup-zfs --zfs-source --restore` support
  * Defaults to latest snapshot
  * Supports `--noop` -> `zfs receive -n`
  * Supports `--restore-verbose`  ->  `zfs receive -v`
  * Use `--zfs-restore-force` -> `zfs receive -F` to rollback target filesystem
* Rename `qmsk.backup-zfs --rsync-restore-delete`