### PR TITLE
Use zfs send --purge-bookmarks / --keep-bookmark to handle failed receive

### DIFF
--- a/bin/qmsk.backup-zfs
+++ b/bin/qmsk.backup-zfs
@@ -197,7 +197,8 @@ class ZFSTarget (BaseTarget):
                 incremental     = '#' + incremental_bookmark if incremental_bookmark else None,
                 snapshot        = None, # create temporary snapshot
                 bookmark        = send_bookmark, # create bookmark for sent snapshot
-                purge_bookmark  = incremental_bookmark, # destroy bookmark for incremental snapshot
+                purge_bookmarks = self.zfs_bookmark + ':' + '*', # destroy bookmarks for previous incremental sends
+                keep_bookmark   = [b for b in (send_bookmark, incremental_bookmark) if b is not None], # keep current and previous bookmark, in case recv fails
                 **self.zfs_send_options
             ) as stream:
                 # create new snapshot with desired name

--- a/bin/qmsk.zfs-ssh-command
+++ b/bin/qmsk.zfs-ssh-command
@@ -41,11 +41,12 @@ class Wrapper:
         Command wrapper
     """
 
-    def __init__(self, noop=None, sudo=None, restrict_raw=None, restrict_glob=None, allow_receive=None, allow_force_receive=None):
+    def __init__(self, noop=None, sudo=None, restrict_raw=None, restrict_glob=None, restrict_bookmarks=None, allow_receive=None, allow_force_receive=None):
         self.noop = noop
         self.sudo = sudo
         self.restrict_raw = restrict_raw
         self.restrict_glob = restrict_glob
+        self.restrict_bookmarks = restrict_bookmarks
         self.allow_receive = allow_receive
         self.allow_force_receive = allow_force_receive
 
@@ -99,6 +100,12 @@ class Wrapper:
         if self.restrict_glob and not any(fnmatch.fnmatch(zfs_name, pattern) for pattern in self.restrict_glob):
             raise Error("Restricted send source: {name}".format(name=zfs_name))
 
+        if args.bookmark and self.restrict_bookmarks and not any(fnmatch.fnmatch(args.bookmark, pattern) for pattern in self.restrict_bookmarks):
+            raise Error("Restricted --bookmark={bookmark}".format(bookmark=args.bookmark))
+
+        if args.purge_bookmark and self.restrict_bookmarks and not any(fnmatch.fnmatch(args.purge_bookmark, pattern) for pattern in self.restrict_bookmarks):
+            raise Error("Restricted --purge-bookmark={bookmark}".format(bookmark=args.purge_bookmark))
+
         zfs = qmsk.backup.zfs.open(zfs_name,
             noop    = self.noop,
             invoker = qmsk.invoke.Invoker(sudo=self.sudo),
@@ -147,6 +154,28 @@ class Wrapper:
         if args.purge_bookmark:
             zfs.destroy_bookmark(args.purge_bookmark)
 
+        if args.purge_bookmarks:
+            if args.keep_bookmark:
+                keep = set(args.keep_bookmark)
+            else:
+                keep = set()
+
+            for bookmark in zfs.list_bookmarks():
+                if not fnmatch.fnmatch(bookmark.name, args.purge_bookmarks):
+                    log.debug("skip bookmark from purge: {bookmark}".format(bookmark=bookmark))
+                    continue
+
+                if self.restrict_bookmarks and not any(fnmatch.fnmatch(bookmark.name, pattern) for pattern in self.restrict_bookmarks):
+                    raise Error("Restricted bookmark: {bookmark}".format(bookmark=bookmark))
+
+                if bookmark.name in keep:
+                    log.debug("keep bookmark from purge: {bookmark}".format(bookmark=bookmark))
+                    continue
+
+                log.info("zfs send %s purge bookmark=%s", zfs_name, bookmark.name)
+
+                bookmark.destroy()
+
         return 0
 
     def zfs(self, args):
@@ -165,6 +194,8 @@ class Wrapper:
         parser_send.add_argument('zfs', metavar='ZFS', help="Source ZFS filesystem, with optional @snapshot")
         parser_send.add_argument('--bookmark', metavar='BOOKMARK', help="Bookmark snapshot after send")
         parser_send.add_argument('--purge-bookmark', metavar='BOOKMARK', help="Destroy bookmark after snapshot send")
+        parser_send.add_argument('--purge-bookmarks', metavar='BOOKMARK-GLOB', help="Destroy matching bookmarks after snapshot send")
+        parser_send.add_argument('--keep-bookmark', action='append', metavar='BOOKMARK', help="Bookmarks to keep, when using --purge-bookmarks")
 
         parser_recv = subparsers.add_parser('receive', aliases=['recv'])
         parser_recv.add_argument('-F', dest='receive_force', action='store_true', help="Force a rollback of the file system to the most recent snapshot before performing the receive operation.")
@@ -220,6 +251,9 @@ def main (args):
     parser.add_argument('--restrict-raw', action='store_true',
             help="Only allow raw snapshot sends")
 
+    parser.add_argument('--restrict-bookmarks', action='append',
+            help="Only allow matching bookmarks")
+
     parser.add_argument('--allow-receive', '--allow-recv', action='store_true',
             help="Also allow zfs recv for restore operations. The --restrict-glob still applies.")
 
@@ -227,6 +261,7 @@ def main (args):
             help="Also allow zfs recv -F for restore operations. Does NOT imply --allow-receive.")
 
     parser.set_defaults(
+        restrict_bookmarks = [],
         restrict_glob = [],
     )
 
@@ -247,10 +282,12 @@ def main (args):
     # run
     try:
         wrapper = Wrapper(
-            noop            = args.noop,
-            sudo            = args.sudo,
-            restrict_raw    = args.restrict_raw,
-            restrict_glob   = args.restrict_glob,
+            noop    = args.noop,
+            sudo    = args.sudo,
+
+            restrict_raw        = args.restrict_raw,
+            restrict_glob       = args.restrict_glob,
+            restrict_bookmarks  = args.restrict_bookmarks,
 
             allow_receive       = args.allow_receive,
             allow_force_receive = args.allow_force_receive,

--- a/bin/qmsk.zfs-ssh-command
+++ b/bin/qmsk.zfs-ssh-command
@@ -125,13 +125,18 @@ class Wrapper:
             # send from temporary snapshot
             snapshot_context = qmsk.backup.zfs.snapshot(zfs, properties={'qmsk-backup:send': incremental_snapshot})
 
+            # cannot send temporarily created snapshot in --noop mode
+            noop_send = self.noop
+
         elif snapshot_name == '*': # zfs send tank/foo@*
             # send from most recent snapshot
             snapshot_context = wrap_context(zfs.last_snapshot())
+            noop_send = False
 
         else: # zfs send tank/foo@xxx
             # send from given snapshot
             snapshot_context = wrap_context(zfs.snapshots[snapshot_name])
+            noop_send = False
 
         log.info("zfs send %s from incremental=%s to snapshot=@%s with bookmark=%s", zfs, send_incremental, snapshot_context, args.bookmark)
 
@@ -145,6 +150,8 @@ class Wrapper:
                 compressed          = args.compressed,
                 large_block         = args.large_block,
                 dedup               = args.dedup,
+
+                noop                = noop_send,
             )
 
             if args.bookmark:

--- a/qmsk/backup/zfs.py
+++ b/qmsk/backup/zfs.py
@@ -172,7 +172,7 @@ class Filesystem (object):
 
         self.zfs_write('create', *args)
 
-    def parse_snapshot(self, name, **opts):
+    def _parse_snapshot(self, name, **opts):
         filesystem, snapshot = name.split('@', 1)
 
         return Snapshot(self, snapshot,
@@ -184,7 +184,7 @@ class Filesystem (object):
         o = ','.join(('name', 'userrefs') + properties)
 
         for name, userrefs, *propvalues in self.zfs_read('list', '-H', '-tsnapshot', '-o' + o, '-r', self.name):
-            snapshot = self.parse_snapshot(name,
+            snapshot = self._parse_snapshot(name,
                     userrefs    = int(userrefs),
                     properties  = {name: (None if value == '-' else value) for name, value in zip(properties, propvalues)},
             )
@@ -247,7 +247,7 @@ class Filesystem (object):
             snapshots = list(self.list_snapshots())
 
         for name, tag, timestamp in self.zfs_read('holds', '-H', *snapshots):
-            snapshot = self.parse_snapshot(name.strip())
+            snapshot = self._parse_snapshot(name.strip())
 
             yield snapshot, tag.strip()
 
@@ -303,12 +303,6 @@ class Filesystem (object):
             pass
 
 class Snapshot (object):
-    @classmethod
-    def parse(cls, name, **opts):
-        filesystem, snapshot = name.split('@', 1)
-
-        return cls(filesystem, snapshot, **opts)
-
     def __init__ (self, filesystem, name, properties={}, noop=None, userrefs=None):
         self.filesystem = filesystem
         self.name = name

--- a/qmsk/backup/zfs.py
+++ b/qmsk/backup/zfs.py
@@ -439,7 +439,7 @@ class Source:
     def __str__(self):
         return self.source
 
-    def stream_send(self, raw=None, compressed=None, large_block=None, dedup=None, incremental=None, full_incremental=None, properties=False, replication_stream=None, snapshot=None, bookmark=None, purge_bookmark=None):
+    def stream_send(self, raw=None, compressed=None, large_block=None, dedup=None, incremental=None, full_incremental=None, properties=False, replication_stream=None, snapshot=None, bookmark=None, purge_bookmark=None, purge_bookmarks=None, keep_bookmark=None):
         """
             Returns a context manager for the send stream.
         """
@@ -464,6 +464,8 @@ class Source:
             # custom qmsk.backup-ssh-command extensions
             bookmark = bookmark,
             purge_bookmark = purge_bookmark,
+            purge_bookmarks = purge_bookmarks,
+            keep_bookmark = keep_bookmark,
         ))
 
     def _receive_opts(self, snapshot=None, force=None, noop=None, verbose=None):

--- a/qmsk/backup/zfs.py
+++ b/qmsk/backup/zfs.py
@@ -102,16 +102,19 @@ class Filesystem (object):
     def __str__(self):
         return self.name
 
-    def zfs_read (self, *args, **opts):
+    def zfs_read (self, *args, noop=None, **opts):
         """
             ZFS wrapper for sudo+noop
 
             Run read-only commands that are also executed when --noop.
         """
 
-        return zfs(*args, invoker=self.invoker, **opts)
+        if noop:
+            return log.warning("noop: zfs %s", args)
+        else:
+            return zfs(*args, invoker=self.invoker, **opts)
 
-    def zfs_stream (self, *args, **opts):
+    def zfs_stream (self, *args, noop=None, **opts):
         """
             ZFS wrapper for sudo+noop
 
@@ -120,7 +123,11 @@ class Filesystem (object):
             Contextmanager yielding stdout stream.
         """
 
-        return zfs_stream(*args, invoker=self.invoker, **opts)
+
+        if noop:
+            return log.warning("noop: zfs %s", args)
+        else:
+            return zfs_stream(*args, invoker=self.invoker, **opts)
 
     def zfs_write (self, *args, **opts):
         """
@@ -379,19 +386,19 @@ class Snapshot (object):
             self,
         )
 
-    def send(self, stdout=True, **options):
+    def send(self, stdout=True, noop=None, **options):
         """
             Write out ZFS contents of this snapshot to stdout.
         """
 
-        return self.filesystem.zfs_read('send', *self._send_options(**options), stdout=stdout)
+        return self.filesystem.zfs_read('send', *self._send_options(**options), stdout=stdout, noop=noop)
 
-    def stream_send(self, **options):
+    def stream_send(self, noop=None, **options):
         """
             Returns a context manager for the send stream.
         """
 
-        return self.filesystem.zfs_stream('send', *self._send_options(**options))
+        return self.filesystem.zfs_stream('send', *self._send_options(**options), noop=noop)
 
 class Bookmark (object):
     def __init__ (self, filesystem, name, properties={}, noop=None):


### PR DESCRIPTION
Fixes #6 

Extends the `qmsk.zfs-ssh-command` wrapper to support new `--purge-bookmarks` and `--keep-bookmark` options, in addition to the existing `--bookmark` and `--purge-bookmark` options.

These new options are used to keep two rolling bookmarks on the source dataset, which allows recovering from failed `zfs recv` operations as described in #6.

Also adds a new `qmsk.zfs-ssh-command --restrict-bookmarks` to only allow specific bookmark prefixes for each SSH key.

This also fixes `qmsk.zfs-ssh-command --noop` to skip the zfs send from the temporary snapshot, which is not created in `--noop` mode, and would fail.